### PR TITLE
Prefix RedisTrait to avoid causing problems for plain RedisAdapter

### DIFF
--- a/src/lib/Symfony/Components/Cache/Adapter/TagAware/RedisTagAwareAdapter.php
+++ b/src/lib/Symfony/Components/Cache/Adapter/TagAware/RedisTagAwareAdapter.php
@@ -19,7 +19,7 @@ use Predis;
 use Predis\Connection\Aggregate\ClusterInterface;
 use Predis\Response\Status;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
-use Symfony\Component\Cache\Traits\RedisTrait;
+use Symfony\Component\Cache\Traits\zRedisTrait;
 
 /**
  * Class RedisTagAwareAdapter, stores tag <> id relationship as a Set so we don't need to fetch tags on get* operations.
@@ -34,7 +34,7 @@ use Symfony\Component\Cache\Traits\RedisTrait;
  */
 final class RedisTagAwareAdapter extends AbstractTagAwareAdapter implements TagAwareAdapterInterface
 {
-    use RedisTrait;
+    use zRedisTrait;
 
     /**
      * Redis "Set" can hold more than 4 billion members, here we limit ourselves to PHP's > 2 billion max int (32Bit).

--- a/src/lib/Symfony/Components/Cache/Tests/Adapter/TagAware/PredisTagAwareAdapterTest.php
+++ b/src/lib/Symfony/Components/Cache/Tests/Adapter/TagAware/PredisTagAwareAdapterTest.php
@@ -36,30 +36,4 @@ class PredisTagAwareAdapterTest extends PredisAdapterTest
 
         return $adapter;
     }
-
-    /**
-     * @todo Drop this overloading when zRedisTrait is removed in the future (IF cluster fixes are backported to 3.4)
-     */
-    public function testCreateConnection()
-    {
-        $redisHost = getenv('REDIS_HOST');
-
-        $redis = RedisAdapter::createConnection('redis://'.$redisHost.'/1', ['class' => \Predis\Client::class, 'timeout' => 3]);
-        $this->assertInstanceOf(\Predis\Client::class, $redis);
-
-        $connection = $redis->getConnection();
-        $this->assertInstanceOf(StreamConnection::class, $connection);
-
-        $params = [
-            'scheme' => 'tcp',
-            'host' => 'localhost',
-            'port' => 6379,
-            'persistent' => 0,
-            'timeout' => 3,
-            'read_write_timeout' => 0,
-            'tcp_nodelay' => true,
-            'database' => '1',
-        ];
-        $this->assertSame($params, $connection->getParameters()->toArray());
-    }
 }

--- a/src/lib/Symfony/Components/Cache/Tests/Adapter/TagAware/PredisTagAwareAdapterTest.php
+++ b/src/lib/Symfony/Components/Cache/Tests/Adapter/TagAware/PredisTagAwareAdapterTest.php
@@ -38,7 +38,7 @@ class PredisTagAwareAdapterTest extends PredisAdapterTest
     }
 
     /**
-     * @todo Drop this overloading when RedisTrait is removedin the future (IF cluster improvments are backported to 3.4)
+     * @todo Drop this overloading when zRedisTrait is removed in the future (IF cluster fixes are backported to 3.4)
      */
     public function testCreateConnection()
     {

--- a/src/lib/Symfony/Components/Cache/Traits/zRedisTrait.php
+++ b/src/lib/Symfony/Components/Cache/Traits/zRedisTrait.php
@@ -27,7 +27,7 @@ use Symfony\Component\Cache\Exception\InvalidArgumentException;
  *
  * @internal
  */
-trait RedisTrait
+trait zRedisTrait
 {
     private static $defaultConnectionOptions = [
         'class' => null,


### PR DESCRIPTION
Realize the backported `RedisTrait` her can cause issues for plain RedisAdapter in Symfony 3.4.

Given intention is to get rid of this and get cluster fixes backported to 3.4 I'm proposing simple trait name prefix. Alternative would be to place it in `EzSystems\SymfonyTools` namespace and adapt it for our CS if needed.

WDYT @kmadejski ?