### PR TITLE
Improve AbstractTagAwareAdapter to mark values without tagaware info as a miss 

### DIFF
--- a/src/lib/Symfony/Components/Cache/Adapter/TagAware/AbstractTagAwareAdapter.php
+++ b/src/lib/Symfony/Components/Cache/Adapter/TagAware/AbstractTagAwareAdapter.php
@@ -65,16 +65,11 @@ abstract class AbstractTagAwareAdapter implements AdapterInterface, LoggerAwareI
             static function ($key, $value, $isHit) use ($defaultLifetime) {
                 $item = new CacheItem();
                 $item->key = $key;
-                $item->isHit = $isHit;
                 $item->defaultLifetime = $defaultLifetime;
                 //<diff:AbstractAdapter> extract Value and Tags from the cache value
-                if (!isset($value['value'])) {
-                    // Value is not in Tagaware format, set as miss so cache is regenerated
-                    $item->isHit = false;
-
-                    return $item;
-                }
-                $item->value = $value['value'];
+                // Mark as miss if value is not in TagAware format
+                $item->isHit = \array_key_exists('value', $value ?? []) ? $isHit : false;
+                $item->value = $value['value'] ?? null;
                 $item->prevTags = $value['tags'] ?? [];
                 //</diff:AbstractAdapter>
 

--- a/src/lib/Symfony/Components/Cache/Adapter/TagAware/AbstractTagAwareAdapter.php
+++ b/src/lib/Symfony/Components/Cache/Adapter/TagAware/AbstractTagAwareAdapter.php
@@ -69,7 +69,7 @@ abstract class AbstractTagAwareAdapter implements AdapterInterface, LoggerAwareI
                 $item->defaultLifetime = $defaultLifetime;
                 //<diff:AbstractAdapter> extract Value and Tags from the cache value
                 if (!isset($value['value'])) {
-                    // value is not Tagaware, set as miss so cache is regnerated
+                    // Value is not in Tagaware format, set as miss so cache is regenerated
                     $item->isHit = false;
 
                     return $item;

--- a/src/lib/Symfony/Components/Cache/Adapter/TagAware/AbstractTagAwareAdapter.php
+++ b/src/lib/Symfony/Components/Cache/Adapter/TagAware/AbstractTagAwareAdapter.php
@@ -68,6 +68,12 @@ abstract class AbstractTagAwareAdapter implements AdapterInterface, LoggerAwareI
                 $item->isHit = $isHit;
                 $item->defaultLifetime = $defaultLifetime;
                 //<diff:AbstractAdapter> extract Value and Tags from the cache value
+                if (!isset($value['value'])) {
+                    // value is not Tagaware, set as miss so cache is regnerated
+                    $item->isHit = false;
+
+                    return $item;
+                }
                 $item->value = $value['value'];
                 $item->prevTags = $value['tags'] ?? [];
                 //</diff:AbstractAdapter>


### PR DESCRIPTION
To avoid situation like:
https://github.com/ezsystems/developer-documentation/pull/594#discussion_r275361822