### PR TITLE
[Abstract] Improve detection of wrong value for cache miss

### DIFF
--- a/src/lib/Symfony/Components/Cache/Adapter/TagAware/AbstractTagAwareAdapter.php
+++ b/src/lib/Symfony/Components/Cache/Adapter/TagAware/AbstractTagAwareAdapter.php
@@ -67,9 +67,13 @@ abstract class AbstractTagAwareAdapter implements AdapterInterface, LoggerAwareI
                 $item->key = $key;
                 $item->defaultLifetime = $defaultLifetime;
                 //<diff:AbstractAdapter> extract Value and Tags from the cache value
-                // Mark as miss if value is not in TagAware format
-                $item->isHit = \array_key_exists('value', $value ?? []) ? $isHit : false;
-                $item->value = $value['value'] ?? null;
+                // If structure does not match what we expect return item as is (no value and not a hit)
+                if (!\is_array($value) || !\array_key_exists('value', $value)) {
+                    return $item;
+                }
+                $item->isHit = $isHit;
+                // Extract value and tags from the cache value
+                $item->value = $value['value'];
                 $item->prevTags = $value['tags'] ?? [];
                 //</diff:AbstractAdapter>
 


### PR DESCRIPTION
Aligns with what ended up as code in Symfony 4 on this so solve issue reported by @wizhippo on slack when value is a single object as opposed to array of values.


_Side note: The implementation in Symfony 4 ended up a bit different then here _(namespace and a few other things)_, once Symfony 4.3 stable is out I intend to adapt the code here to backport as is, and will probably need to provide deprecated classes aor class aliases to not break stable installs._