### PR TITLE
Make the doSave method compatible with Symfony\Component\Cache\Traits\AbstractTrait::doSave

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "cache/integration-tests": "dev-master",
     "friendsofphp/php-cs-fixer": "^2.14.6",
     "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-    "phpunit/phpunit": "^7.5|^9.4",
+    "phpunit/phpunit": "^7.5",
     "predis/predis": "^1.1.1",
     "symfony/phpunit-bridge": "~3.4|~4.0",
     "phpstan/phpstan": "^0.12.88"

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
   "scripts": {
     "fix-cs": "php-cs-fixer fix -v --show-progress=estimating",
     "check-cs": "php-cs-fixer fix --dry-run -v --diff --show-progress=estimating",
-    "test": "simple-phpunit",
+    "test": "phpunit -c phpunix.xml.dist",
     "phpstan": "phpstan analyse -c phpstan.neon"
   },
   "scripts-descriptions": {

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
   "require-dev": {
     "cache/integration-tests": "dev-master",
     "friendsofphp/php-cs-fixer": "^2.14.6",
-    "phpdocumentor/reflection-docblock": "^3.0|^4.0",
-    "phpunit/phpunit": "^7.5",
+    "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+    "phpunit/phpunit": "^7.5|^9.4",
     "predis/predis": "^1.1.1",
     "symfony/phpunit-bridge": "~3.4|~4.0",
     "phpstan/phpstan": "^0.12.88"

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
   "scripts": {
     "fix-cs": "php-cs-fixer fix -v --show-progress=estimating",
     "check-cs": "php-cs-fixer fix --dry-run -v --diff --show-progress=estimating",
-    "test": "phpunit -c phpunix.xml.dist",
+    "test": "phpunit -c phpunit.xml.dist",
     "phpstan": "phpstan analyse -c phpstan.neon"
   },
   "scripts-descriptions": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,6 @@
         <ini name="error_reporting" value="-1" />
         <env name="REDIS_HOST" value="localhost" />
         <env name="MEMCACHED_HOST" value="localhost" />
-        <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT" value="1" />
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1" />
         <env name="REDIS_HOST" value="localhost" />
         <env name="MEMCACHED_HOST" value="localhost" />
+        <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT" value="1" />
     </php>
 
     <testsuites>

--- a/src/lib/Symfony/Components/Cache/Adapter/AbstractTagAwareAdapter.php
+++ b/src/lib/Symfony/Components/Cache/Adapter/AbstractTagAwareAdapter.php
@@ -145,7 +145,7 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, Logg
      *
      * @return array The identifiers that failed to be cached or a boolean stating if caching succeeded or not
      */
-    abstract protected function doSave(array $values, int $lifetime, array $addTagData = [], array $removeTagData = []): array;
+    abstract protected function doSave(array $values, $lifetime, array $addTagData = [], array $removeTagData = []): array;
 
     /**
      * Removes multiple items from the pool and their corresponding tags.

--- a/src/lib/Symfony/Components/Cache/Adapter/FilesystemTagAwareAdapter.php
+++ b/src/lib/Symfony/Components/Cache/Adapter/FilesystemTagAwareAdapter.php
@@ -101,7 +101,7 @@ class FilesystemTagAwareAdapter extends AbstractTagAwareAdapter implements Prune
      *
      * {@inheritdoc}
      */
-    protected function doSave(array $values, int $lifetime, array $addTagData = [], array $removeTagData = []): array
+    protected function doSave(array $values, $lifetime, array $addTagData = [], array $removeTagData = []): array
     {
         $failed = [];
         $serialized = self::$marshaller->marshall($values, $failed);

--- a/src/lib/Symfony/Components/Cache/Adapter/RedisTagAwareAdapter.php
+++ b/src/lib/Symfony/Components/Cache/Adapter/RedisTagAwareAdapter.php
@@ -119,7 +119,7 @@ class RedisTagAwareAdapter extends AbstractTagAwareAdapter
     /**
      * {@inheritdoc}
      */
-    protected function doSave(array $values, int $lifetime, array $addTagData = [], array $delTagData = []): array
+    protected function doSave(array $values, $lifetime, array $addTagData = [], array $delTagData = []): array
     {
         $eviction = $this->getRedisEvictionPolicy();
         if ('noeviction' !== $eviction && 0 !== strpos($eviction, 'volatile-')) {


### PR DESCRIPTION
Current implementation is working fine, but in theory is not correct as it does not follow the rules of contravariance.

Moreover, it fails in PHP 8 (I am testing eZ Platform 2.5 on PHP 8 with `--ignore-platform-reqs`) as PHP 8 introduces the validation of abstract trait methods:

https://3v4l.org/hVGRg

Can this be merged and tagged since it does not introduce any breaking change and allows me to play with eZ Platform 2.5 on PHP 8?

Thanks!