### PR TITLE
Added basic CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request: ~
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: "ubuntu-20.04"
+    timeout-minutes: 10
+    continue-on-error: ${{ matrix.experimental }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - '7.1'
+          - '7.2'
+          - '7.3'
+          - '7.4'
+        composer_options: [ "" ]
+        experimental: [false]
+        include:
+          - php: '8.0'
+            composer_options: "--ignore-platform-req php"
+            experimental: true
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP Action
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          extensions: redis
+          tools: cs2pr
+
+      - uses: "ramsey/composer-install@v1"
+        with:
+          dependency-versions: "highest"
+          composer-options: "--prefer-dist --no-progress --no-suggest ${{ matrix.composer_options }}"
+
+      - name: Setup problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Run PHPStan analysis
+        run: composer run-script phpstan
+
+      - name: Run code style check
+        run: composer run-script check-cs -- --format=checkstyle | cs2pr
+
+      - name: Run test suite
+        run: composer run-script --timeout=600 test

--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,12 @@
   },
   "require-dev": {
     "cache/integration-tests": "dev-master",
-    "friendsofphp/php-cs-fixer": "v2.14.6",
+    "friendsofphp/php-cs-fixer": "^2.14.6",
     "phpdocumentor/reflection-docblock": "^3.0|^4.0",
     "phpunit/phpunit": "^7.5",
     "predis/predis": "^1.1.1",
-    "symfony/phpunit-bridge": "~3.4|~4.0"
-
+    "symfony/phpunit-bridge": "~3.4|~4.0",
+    "phpstan/phpstan": "^0.12.88"
   },
   "conflict": {
       "ezsystems/ezpublish-kernel": "7.0 - 7.3.4 | 7.4.0 - 7.4.2"
@@ -47,7 +47,15 @@
       }
   },
   "scripts": {
-    "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating",
-    "test": "@php ./vendor/bin/simple-phpunit"
+    "fix-cs": "php-cs-fixer fix -v --show-progress=estimating",
+    "check-cs": "php-cs-fixer fix --dry-run -v --diff --show-progress=estimating",
+    "test": "simple-phpunit",
+    "phpstan": "phpstan analyse -c phpstan.neon"
+  },
+  "scripts-descriptions": {
+    "fix-cs": "Automatically fixes code style in all files",
+    "check-cs": "Run code style checker for all files",
+    "test": "Run automatic tests",
+    "phpstan": "Run static code analysis"
   }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,22 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Undefined variable\\: \\$expiredIds$#"
+			count: 2
+			path: src/lib/Symfony/Components/Cache/Adapter/AbstractTagAwareAdapter.php
+
+		-
+			message: "#^Instantiated class Symfony\\\\Component\\\\Cache\\\\Adapter\\\\CacheException not found\\.$#"
+			count: 1
+			path: src/lib/Symfony/Components/Cache/Adapter/FilesystemTagAwareAdapter.php
+
+		-
+			message: "#^Access to an undefined property Predis\\\\Configuration\\\\OptionsInterface\\:\\:\\$options\\.$#"
+			count: 1
+			path: src/lib/Symfony/Components/Cache/Adapter/RedisTagAwareAdapter.php
+
+		-
+			message: "#^Class Symfony\\\\Component\\\\Cache\\\\Traits\\\\RedisClusterProxy not found\\.$#"
+			count: 1
+			path: src/lib/Symfony/Components/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 1
+    paths:
+        - src


### PR DESCRIPTION
Tests for #12.

The same CI pipeline is used as we're introducing in our repositories, with one difference: PHPStan level is set to only 1 to prevent polluting baseline file with errors that we are not expecting to fix.

@emodric @alongosz 