### PR TITLE
Setting an expiry on SETS too

### DIFF
--- a/src/lib/Symfony/Components/Cache/Adapter/RedisTagAwareAdapter.php
+++ b/src/lib/Symfony/Components/Cache/Adapter/RedisTagAwareAdapter.php
@@ -146,6 +146,7 @@ class RedisTagAwareAdapter extends AbstractTagAwareAdapter
             foreach ($addTagData as $tagId => $ids) {
                 if (!$failed || $ids = array_diff($ids, $failed)) {
                     yield 'sAdd' => array_merge([$tagId], $ids);
+                    yield 'expire' => [$tagId, 0 >= $lifetime ? self::DEFAULT_CACHE_TTL : $lifetime,];
                 }
             }
 


### PR DESCRIPTION
As stated in [doc](https://doc.ibexa.co/en/latest/guide/persistence_cache/#supported-adapters), the `RedisTagAwareAdapter` requires Eviction policies to be either `volatile-ttl`, `volatile-lru` or `volatile-lfu`. However, in order for volatile eviction methods to work, [the records MUST have an `expiry`](https://redis.io/topics/lru-cache#eviction-policies)

However, for whatever reason we do not set an expiry on Sets, only on strings. I guess it was just forgotten

[IBX-456](https://issues.ibexa.co/browse/IBX-456)